### PR TITLE
Update loader.py

### DIFF
--- a/src/super_image/data/loader.py
+++ b/src/super_image/data/loader.py
@@ -11,7 +11,7 @@ class ImageLoader:
     def load_image(image: Image):
         lr = np.array(image.convert('RGB'))
         lr = lr[::].astype(np.float32).transpose([2, 0, 1]) / 255.0
-        return torch.as_tensor([lr])
+        return torch.as_tensor(np.array([lr]))
 
     @staticmethod
     def _process_image_to_save(pred: Tensor):


### PR DESCRIPTION
added np.array to avoid a warning that is popping everytime using the load_image
```
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at  ..\torch\csrc\utils\tensor_new.cpp:204.)
  return torch.as_tensor([lr])
  ```