### PR TITLE
Use np.array on image_load

### DIFF
--- a/src/super_image/data/loader.py
+++ b/src/super_image/data/loader.py
@@ -11,7 +11,7 @@ class ImageLoader:
     def load_image(image: Image):
         lr = np.array(image.convert('RGB'))
         lr = lr[::].astype(np.float32).transpose([2, 0, 1]) / 255.0
-        return torch.as_tensor(np.array([lr]))
+        return torch.as_tensor(np.array(np.array([lr])))
 
     @staticmethod
     def _process_image_to_save(pred: Tensor):


### PR DESCRIPTION
Fixes the warning from torch:
```
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list  to a single numpy.ndarray with numpy.array() before converting to a tensor.
```

Has a noticable speed up on loading images -- seemed to be about 6x faster per image loaded on 2k images.
